### PR TITLE
Allow custom file pattern matching

### DIFF
--- a/BeautifyRuby.sublime-settings
+++ b/BeautifyRuby.sublime-settings
@@ -3,5 +3,6 @@
   // The default is two spaces represented by 'space'
   // anything else will use one tab character
   "tab_or_space": "space",
-  "ruby": "/usr/bin/env ruby"
+  "ruby": "/usr/bin/env ruby",
+  "file_patterns": [ ".rb", ".rake" ]
 }

--- a/beautify_ruby.py
+++ b/beautify_ruby.py
@@ -58,7 +58,8 @@ class BeautifyRubyCommand(sublime_plugin.TextCommand):
     return command
 
   def is_ruby_file(self, fname):
-    patterns = re.compile(r'\.rb|\.rake')
+    file_patterns = self.settings.get('file_patterns') or ['.rb', '.rake']
+    patterns = re.compile(r'\b(?:%s)\b' % '|'.join(file_patterns))
     if patterns.search(fname):
       return True
     else:


### PR DESCRIPTION
This pull request:
- adds a `file_patterns` pair to sublime-settings with an array of file patterns to match as valid Ruby
- modifies `is_ruby_file` method to pull the  list of valid file patterns from the sublime-settings
- adds word boundaries to regex

With these changes, I can now beautify files with non-standard file names, e.g. Gemfile, Rakefile, etc., by modifying `BeautifyRuby.sublime-settings`:

``` json
{
  "tab_or_space": "space",
  "ruby": "/usr/bin/env ruby",
  "file_patterns": [ ".rb", ".rake", "Gemfile", "Rakefile" ]
}
```
