### PR TITLE
Fix syntax error (missing comma)

### DIFF
--- a/BeautifyRuby.sublime-settings
+++ b/BeautifyRuby.sublime-settings
@@ -3,7 +3,7 @@
   // The default is two spaces represented by 'space'
   // anything else will use one tab character
   "tab_or_space": "space",
-  "ruby": "/usr/bin/env ruby"
+  "ruby": "/usr/bin/env ruby",
   "file_patterns": [ "\\.html\\.erb", "\\.rb", "\\.rake", "Rakefile", "Gemfile" ],
   "run_on_save": false,
   "save_on_beautify": true


### PR DESCRIPTION
This sneaked in with the last commit on that file and produces an error when saving the first ruby file after starting sublime.
