### PR TITLE
fix problem with files contains utf-8 symbols

### DIFF
--- a/beautify_ruby.py
+++ b/beautify_ruby.py
@@ -34,7 +34,7 @@ class BeautifyRubyCommand(sublime_plugin.TextCommand):
     working_dir = os.path.dirname(self.filename)
     body = self.active_view.substr(self.buffer_region)
     beautifier = subprocess.Popen(self.cmd(), shell=True, cwd=working_dir, stdin=subprocess.PIPE, stdout=subprocess.PIPE)
-    out = beautifier.communicate(body)[0].decode('utf8')
+    out = beautifier.communicate(body.encode("utf-8"))[0].decode('utf8')
     if (out == "" and body != ""):
       sublime.error_message("check your ruby interpreter settings")
       return body


### PR DESCRIPTION
Fix this error:

File "./beautify_ruby.py", line 37, in beautify_buffer
  File "/System/Library/Frameworks/Python.framework/Versions/2.6/lib/python2.6/subprocess.py", line 671, in communicate
    return self._communicate(input)

UnicodeEncodeError: 'ascii' codec can't encode character u'\u0432' in position 395: ordinal not in range(128)
