### PR TITLE
allow setting html erb file name patters

### DIFF
--- a/beautify_ruby.py
+++ b/beautify_ruby.py
@@ -81,7 +81,9 @@ class BeautifyRubyCommand(sublime_plugin.TextCommand):
     return command
 
   def is_erb_file(self):
-    if re.search("\.html\.erb", self.fname):
+    file_patterns = self.settings.get('html_erb_patterns') or ["\.html\.erb"]
+    patterns = re.compile(r'\b(?:%s)\b' % '|'.join(file_patterns))
+    if patterns.search(self.fname):
       return True
     else:
       return False
@@ -90,6 +92,8 @@ class BeautifyRubyCommand(sublime_plugin.TextCommand):
     self.filename = self.view.window().active_view().file_name()
     self.fname         = os.path.basename(self.filename)
     file_patterns = self.settings.get('file_patterns') or ['.rb', '.rake']
+    if self.settings.get('html_erb_patterns'):
+      file_patterns  = file_patterns + self.settings.get('html_erb_patterns')
     patterns = re.compile(r'\b(?:%s)\b' % '|'.join(file_patterns))
     if patterns.search(self.fname):
       return True


### PR DESCRIPTION
Sometimes we have html erb templates that do not have .html in the file name his pull requests allows the user to describe file their own .html.erb file extensions.  Patterns added to "html_erb_patterns" are added to "file_patterns" so there is no need to redundancy.

example settings:

```
{
  // Would you prefer a tab or two spaces to represent a tab
  // The default is two spaces represented by 'space'
  // anything else will use one tab character
  "tab_or_space": "space",
  "ruby": "~/.rvm/bin/rvm-auto-ruby",
  "file_patterns": [ "\\.rb", "\\.rake", "Rakefile", "Gemfile" ],
  "html_erb_patterns": [ "\\.mobile\\.erb","\\.html\\.erb"],
  "run_on_save": false,
  "save_on_beautify": true
}
```
