### PR TITLE
Remove shift for private/protected/public.

### DIFF
--- a/lib/rbeautify/config/ruby.rb
+++ b/lib/rbeautify/config/ruby.rb
@@ -62,13 +62,6 @@ unless RBeautify::Language.language(:ruby)
                    /(((^|;|\s)end)|#{continue_statement_boundary}(rescue|ensure))\b/,
                    :nest_except => [:double_quote, :regex, :backtick])
 
-  ruby.add_matcher(:visibility,
-                   /(private|protected|public)\s*$/,
-                   /(private|protected|public)\s*$/,
-                   :nest_except => [:double_quote, :regex, :backtick],
-                   :end => :implicit,
-                   :end_can_also_be_start => true)
-
   ruby.add_matcher(:more,
                    /#{start_statement_boundary}(until|for|while)\b/,
                    /(((^|;|\s)end)|#{continue_statement_boundary}(rescue|ensure))\b/,


### PR DESCRIPTION
It's not right to add shift after private/protected/public. The indention after private/protected/public is totally wrong formatted.

A normal ruby code should be this way:

``` ruby
class Bla
  private
  def some_method
  end
end
```

But the now after running BeautifyRuby, it becomes this:

``` ruby
class Bla
    private
      def some_method
      end
  end
```

Notice the heading space of the last line, it shouldn't be that way. When I use both BeautifyRuby and SublimeLinter, a warning will be raised to tell me there's a mismatch. So, there shouldn't be any shift after private/protected/public.
