### PR TITLE
Don't return partial results when htmlbeautifier raises an exception

### DIFF
--- a/lib/erbbeautify.rb
+++ b/lib/erbbeautify.rb
@@ -2,8 +2,15 @@ require 'rubygems'
 require 'htmlbeautifier'
 
 def beautify(input, output)
-  HtmlBeautifier::Beautifier.new(output).scan(input)
-  output << "\n"
+  dest = ""
+  beautifier = HtmlBeautifier::Beautifier.new(dest)
+  begin
+    beautifier.scan(input)
+    dest << "\n"
+  rescue
+    dest = ""
+  end
+  output.write(dest)
 end
 
 beautify $stdin.read, $stdout


### PR DESCRIPTION
When htmlbeautifier raises an exception, results that have already been written to stdout in erbbeautify.rb are applied to the erb template and the rest of the template is lost. 

For example the following erb snippet:

```
<% if cond
# This comment causes an "Outdented too far" error on line 5
%>
True
<% else %>
False
<% end %>
```

will be beautified to this:

```
<% if cond
# This comment causes an "Outdented too far" error on line 5
%>
True
```

This PR changes the erbbeautify.rb to:
- process the whole template before writing the result to stdout
- write an empty string on error. ST will then show the "Error: invalid output. Check your ruby interpreter settings" message instead of producing incorrect output.
