### PR TITLE
Upgrade specs to use RSpec 3.x

### DIFF
--- a/spec/fixtures/ruby.yml
+++ b/spec/fixtures/ruby.yml
@@ -132,7 +132,7 @@
     second_arg,
     # Comment in the middle of all this
     third_arg
-    
+
     another_method_call
     end
   output: |
@@ -141,7 +141,7 @@
         second_arg,
         # Comment in the middle of all this
         third_arg
-    
+
       another_method_call
     end
 
@@ -151,7 +151,7 @@
     multiline_method_call.
     foo.
     bar
-    
+
     another_method_call
     end
   output: |
@@ -159,7 +159,7 @@
       multiline_method_call.
         foo.
         bar
-    
+
       another_method_call
     end
 

--- a/spec/rbeautify/block_matcher_spec.rb
+++ b/spec/rbeautify/block_matcher_spec.rb
@@ -9,81 +9,95 @@ describe RBeautify::BlockMatcher do
       end
 
       it 'should not match de' do
-        RBeautify::BlockMatcher.parse(@ruby, nil, 0, 'de foo', 0).should be_nil
+        expect(RBeautify::BlockMatcher.parse(@ruby, nil, 0, 'de foo', 0)).to eq(nil)
       end
 
       it 'should match def' do
         block = RBeautify::BlockMatcher.parse(@ruby, nil, 0, 'def foo', 0)
-        block.should_not be_nil
-        block.name.should == :standard
+        expect(block).to_not eq(nil)
+        expect(block.name).to eq(:standard)
       end
 
       it 'should be nested block' do
         block = RBeautify::BlockMatcher.parse(@ruby, nil, 0, 'if {', 0)
-        block.should_not be_nil
-        block.name.should == :curly_bracket
-        block.parent.should_not be_nil
-        block.parent.name.should == :if
+        expect(block).to_not eq(nil)
+        expect(block.name).to eq(:curly_bracket)
+        expect(block.parent).to_not eq(nil)
+        expect(block.parent.name).to eq(:if)
       end
 
       it 'should be nested block (taking into account ends)' do
         block = RBeautify::BlockMatcher.parse(@ruby, nil, 0, 'if {}', 0)
-        block.should_not be_nil
-        block.name.should == :if
+        expect(block).to_not eq(nil)
+        expect(block.name).to eq(:if)
       end
 
       it 'should be deeply nested block (taking into account ends)' do
         block = RBeautify::BlockMatcher.parse(@ruby, nil, 0, 'def foo(bar = {})', 0)
-        block.should_not be_nil
-        block.name.should == :standard
-        block.parent.should be_nil
+        expect(block).to_not eq(nil)
+        expect(block.name).to eq(:standard)
+        expect(block.parent).to eq(nil)
       end
 
       it 'should current block if no started or ended blocks' do
         block = RBeautify::BlockStart.new(@ruby.matcher(:standard), nil, 0, 0, 'def', ' foo')
-        RBeautify::BlockMatcher.parse(@ruby, block, 0, 'a = 3', 0).should == block
+        expect(RBeautify::BlockMatcher.parse(@ruby, block, 0, 'a = 3', 0)).to eq(block)
       end
 
       it 'should be newly started block if ends and starts' do
         current_block = RBeautify::BlockStart.new(@ruby.matcher(:if), nil, 0, 0, 'if', ' foo')
         block = RBeautify::BlockMatcher.parse(@ruby, current_block, 0, 'else', 0)
-        block.should_not be_nil
-        block.name.should == :if
-        block.parent.should be_nil
+        expect(block).to_not eq(nil)
+        expect(block.name).to eq(:if)
+        expect(block.parent).to eq(nil)
       end
 
       it 'should be parent block if current block ends' do
         parent_block = RBeautify::BlockStart.new(@ruby.matcher(:standard), nil, 0, 0, 'class', ' Foo')
         child_block = RBeautify::BlockStart.new(@ruby.matcher(:standard), parent_block, 0, 0, 'def', ' foo')
-        RBeautify::BlockMatcher.parse(@ruby, child_block, 0, 'end', 0).should == parent_block
+        expect(RBeautify::BlockMatcher.parse(@ruby, child_block, 0, 'end', 0)).to eq(parent_block)
       end
 
       it 'should remove two blocks if top of stack ends implicitly' do
         parent_block = RBeautify::BlockStart.new(@ruby.matcher(:case), nil, 0, 0, 'case', ' foo')
         child_block = RBeautify::BlockStart.new(@ruby.matcher(:inner_case), parent_block, 0, 0, 'when', '2')
-        RBeautify::BlockMatcher.parse(@ruby, child_block, 0, 'end', 0).should be_nil
+        expect(RBeautify::BlockMatcher.parse(@ruby, child_block, 0, 'end', 0)).to eq(nil)
       end
     end
   end
 
   describe '#can_nest?' do
     before(:each) do
-      @language = mock(RBeautify::Language)
+      @language = double(RBeautify::Language)
     end
 
-    it { RBeautify::BlockMatcher.new(@language, :foo, /foo/, /bar/).should be_can_nest(nil) }
+    it {
+      expect(RBeautify::BlockMatcher.new(@language, :foo, /foo/, /bar/)).to be_can_nest(nil)
+    }
 
-    it { RBeautify::BlockMatcher.new(@language, :foo, /foo/, /bar/).should be_can_nest(mock('block_start', :parse_content? => true)) }
+    it {
+      expect(RBeautify::BlockMatcher.new(@language, :foo, /foo/, /bar/)).to be_can_nest(double('block_start', :parse_content? => true))
+    }
 
-    it { RBeautify::BlockMatcher.new(@language, :foo, /foo/, /bar/).should_not be_can_nest(mock('block_start', :parse_content? => false)) }
+    it {
+      expect(RBeautify::BlockMatcher.new(@language, :foo, /foo/, /bar/)).to_not be_can_nest(double('block_start', :parse_content? => false))
+    }
 
-    it { RBeautify::BlockMatcher.new(@language, :foo, /foo/, /bar/, :nest_except => [:bar]).should be_can_nest(nil) }
+    it {
+      expect(RBeautify::BlockMatcher.new(@language, :foo, /foo/, /bar/, :nest_except => [:bar])).to be_can_nest(nil)
+    }
 
-    it { RBeautify::BlockMatcher.new(@language, :foo, /foo/, /bar/, :nest_except => [:foo]).should be_can_nest(mock('block_start', :name => :bar, :parse_content? => true)) }
+    it {
+      expect(RBeautify::BlockMatcher.new(@language, :foo, /foo/, /bar/, :nest_except => [:foo])).to be_can_nest(double('block_start', :name => :bar, :parse_content? => true))
+    }
 
-    it { RBeautify::BlockMatcher.new(@language, :foo, /foo/, /bar/, :nest_except => [:foo]).should_not be_can_nest(mock('block_start', :name => :bar, :parse_content? => false)) }
+    it {
+      expect(RBeautify::BlockMatcher.new(@language, :foo, /foo/, /bar/, :nest_except => [:foo])).to_not be_can_nest(double('block_start', :name => :bar, :parse_content? => false))
+    }
 
-    it { RBeautify::BlockMatcher.new(@language, :foo, /foo/, /bar/, :nest_except => [:bar]).should_not be_can_nest(mock('block_start', :name => :bar, :parse_content? => true)) }
+    it {
+      expect(RBeautify::BlockMatcher.new(@language, :foo, /foo/, /bar/, :nest_except => [:bar])).to_not be_can_nest(double('block_start', :name => :bar, :parse_content? => true))
+    }
   end
 
 end

--- a/spec/rbeautify/block_start_spec.rb
+++ b/spec/rbeautify/block_start_spec.rb
@@ -15,11 +15,21 @@ describe RBeautify::BlockStart do
         @unrelated = RBeautify::BlockStart.new(@ruby.matcher(:standard), nil, 0, 0, 'class', ' Bar')
       end
 
-      it { RBeautify::BlockStart.first_common_ancestor(@grand_parent, nil).should be_nil }
-      it { RBeautify::BlockStart.first_common_ancestor(@grand_parent, @unrelated).should be_nil }
-      it { RBeautify::BlockStart.first_common_ancestor(@grand_parent, @parent).should == @grand_parent }
-      it { RBeautify::BlockStart.first_common_ancestor(@grand_parent, @first).should == @grand_parent }
-      it { RBeautify::BlockStart.first_common_ancestor(@first, @second).should == @parent }
+      it {
+        expect(RBeautify::BlockStart.first_common_ancestor(@grand_parent, nil)).to eq(nil)
+      }
+      it {
+        expect(RBeautify::BlockStart.first_common_ancestor(@grand_parent, @unrelated)).to be_nil
+      }
+      it {
+        expect(RBeautify::BlockStart.first_common_ancestor(@grand_parent, @parent)).to eq(@grand_parent )
+      }
+      it {
+        expect(RBeautify::BlockStart.first_common_ancestor(@grand_parent, @first)).to eq(@grand_parent )
+      }
+      it {
+        expect(RBeautify::BlockStart.first_common_ancestor(@first, @second)).to eq(@parent)
+      }
     end
   end
 
@@ -28,11 +38,10 @@ describe RBeautify::BlockStart do
       @block = RBeautify::BlockStart.new(@ruby.matcher(:standard), nil, 0, 'def', ' foo', 0)
     end
 
-    it { @block.should_not be_strict_ancestor_of(nil) }
-    it { @block.should_not be_strict_ancestor_of(@block) }
-    it { @block.should_not be_strict_ancestor_of(RBeautify::BlockStart.new(@ruby.matcher(:if), nil, 0, 0, 'if', ' foo') ) }
-    it { @block.should be_strict_ancestor_of(RBeautify::BlockStart.new(@ruby.matcher(:if), @block, 0, 0, 'if', ' foo') ) }
-
+    it { expect(@block).to_not be_strict_ancestor_of(nil) }
+    it { expect(@block).to_not be_strict_ancestor_of(@block) }
+    it { expect(@block).to_not be_strict_ancestor_of(RBeautify::BlockStart.new(@ruby.matcher(:if), nil, 0, 0, 'if', ' foo') ) }
+    it { expect(@block).to be_strict_ancestor_of(RBeautify::BlockStart.new(@ruby.matcher(:if), @block, 0, 0, 'if', ' foo') ) }
   end
 
   describe '#total_indent_size' do
@@ -40,11 +49,13 @@ describe RBeautify::BlockStart do
       @block = RBeautify::BlockStart.new(@ruby.matcher(:standard), nil, 0, 'def', ' foo', 0)
     end
 
-    it { RBeautify::BlockStart.new(@ruby.matcher(:standard), nil, 0, 0, 'def', ' foo') .total_indent_size.should == 2 }
+    it {
+      expect(RBeautify::BlockStart.new(@ruby.matcher(:standard), nil, 0, 0, 'def', ' foo').total_indent_size).to eq(2)
+    }
 
     it 'should sum with parents total indent size' do
-      parent = mock('parent_start_block', :total_indent_size => 4)
-      RBeautify::BlockStart.new(@ruby.matcher(:standard), parent, 0, 0, 'def', ' foo') .total_indent_size.should == 6
+      parent = double('parent_start_block', :total_indent_size => 4)
+      expect(RBeautify::BlockStart.new(@ruby.matcher(:standard), parent, 0, 0, 'def', ' foo').total_indent_size).to eq(6)
     end
   end
 

--- a/spec/rbeautify/config/ruby_spec.rb
+++ b/spec/rbeautify/config/ruby_spec.rb
@@ -15,17 +15,17 @@ describe 'Ruby' do
         @current_block = RBeautify::BlockStart.new(@matcher, nil, 0, 0, '', '')
       end
 
-      it { @matcher.parse_block_start('class Foo; end', nil, 0, 0).should be_block_start_like(:standard, 0, 'class', ' Foo; end') }
-      it { @matcher.parse_block_start('module Foo', nil, 0, 0).should be_block_start_like(:standard, 0, 'module', ' Foo') }
-      it { @matcher.parse_block_start('def foo()', nil, 0, 0).should be_block_start_like(:standard, 0, 'def', ' foo()') }
-      it { @matcher.parse_block_start('end Foo', nil, 0, 0).should be_nil }
+      it { expect(@matcher.parse_block_start('class Foo; end', nil, 0, 0)).to be_block_start_like(:standard, 0, 'class', ' Foo; end') }
+      it { expect(@matcher.parse_block_start('module Foo', nil, 0, 0)).to be_block_start_like(:standard, 0, 'module', ' Foo') }
+      it { expect(@matcher.parse_block_start('def foo()', nil, 0, 0)).to be_block_start_like(:standard, 0, 'def', ' foo()') }
+      it { expect(@matcher.parse_block_start('end Foo', nil, 0, 0)).to be_nil }
 
-      it { @current_block.parse_block_end('end', 0).should be_block_end_like(@current_block, 0, 'end', '') }
-      it { @current_block.parse_block_end(';end', 0).should be_block_end_like(@current_block, 0, ';end', '') }
-      it { @current_block.parse_block_end('; end', 0).should be_block_end_like(@current_block, 1, ' end', '') }
-      it { @current_block.parse_block_end('rescue', 0).should be_block_end_like(@current_block, 0, 'rescue', '') }
-      it { @current_block.parse_block_end('ensure', 0).should be_block_end_like(@current_block, 0, 'ensure', '') }
-      it { @current_block.parse_block_end('}', 0).should be_nil }
+      it { expect(@current_block.parse_block_end('end', 0)).to be_block_end_like(@current_block, 0, 'end', '') }
+      it { expect(@current_block.parse_block_end(';end', 0)).to be_block_end_like(@current_block, 0, ';end', '') }
+      it { expect(@current_block.parse_block_end('; end', 0)).to be_block_end_like(@current_block, 1, ' end', '') }
+      it { expect(@current_block.parse_block_end('rescue', 0)).to be_block_end_like(@current_block, 0, 'rescue', '') }
+      it { expect(@current_block.parse_block_end('ensure', 0)).to be_block_end_like(@current_block, 0, 'ensure', '') }
+      it { expect(@current_block.parse_block_end('}', 0)).to be_nil }
     end
 
     describe 'if' do
@@ -34,16 +34,16 @@ describe 'Ruby' do
         @current_block = RBeautify::BlockStart.new(@matcher, nil, 0, 0, 'if', ' foo')
       end
 
-      it { @matcher.should be_end_can_also_be_start}
+      it { expect(@matcher).to be_end_can_also_be_start}
 
-      it { @matcher.parse_block_start('if foo', nil, 0, 0).should be_block_start_like(:if, 0, 'if', ' foo') }
-      it { @matcher.parse_block_start('then foo = bar', nil, 0, 0).should be_block_start_like(:if, 0, 'then', ' foo = bar') }
-      it { @matcher.parse_block_start('if_foo', nil, 0, 0).should be_nil }
+      it { expect(@matcher.parse_block_start('if foo', nil, 0, 0)).to be_block_start_like(:if, 0, 'if', ' foo') }
+      it { expect(@matcher.parse_block_start('then foo = bar', nil, 0, 0)).to be_block_start_like(:if, 0, 'then', ' foo = bar') }
+      it { expect(@matcher.parse_block_start('if_foo', nil, 0, 0)).to be_nil }
 
-      it { @current_block.parse_block_end('end', 0).should be_block_end_like(@current_block, 0, 'end', '') }
-      it { @current_block.parse_block_end('then', 0).should be_block_end_like(@current_block, 0, 'then', '') }
-      it { @current_block.parse_block_end('else', 0).should be_block_end_like(@current_block, 0, 'else', '') }
-      it { @current_block.parse_block_end('a = 3', 0).should be_nil }
+      it { expect(@current_block.parse_block_end('end', 0)).to be_block_end_like(@current_block, 0, 'end', '') }
+      it { expect(@current_block.parse_block_end('then', 0)).to be_block_end_like(@current_block, 0, 'then', '') }
+      it { expect(@current_block.parse_block_end('else', 0)).to be_block_end_like(@current_block, 0, 'else', '') }
+      it { expect(@current_block.parse_block_end('a = 3', 0)).to be_nil }
     end
 
     describe 'curly_bracket' do
@@ -52,11 +52,11 @@ describe 'Ruby' do
         @current_block = RBeautify::BlockStart.new(@matcher, nil, 0, 0, '{', '')
       end
 
-      it { @matcher.parse_block_start('{', nil, 0, 0).should be_block_start_like(:curly_bracket, 0, '{', '') }
-      it { @matcher.parse_block_start('end', nil, 0, 0).should be_nil }
+      it { expect(@matcher.parse_block_start('{', nil, 0, 0)).to be_block_start_like(:curly_bracket, 0, '{', '') }
+      it { expect(@matcher.parse_block_start('end', nil, 0, 0)).to be_nil }
 
-      it { @current_block.parse_block_end('}', 0).should be_block_end_like(@current_block, 0, '}', '') }
-      it { @current_block.parse_block_end('end', 0).should be_nil }
+      it { expect(@current_block.parse_block_end('}', 0)).to be_block_end_like(@current_block, 0, '}', '') }
+      it { expect(@current_block.parse_block_end('end', 0)).to be_nil }
 
     end
 
@@ -66,16 +66,16 @@ describe 'Ruby' do
         @current_block = RBeautify::BlockStart.new(@matcher, nil, 0, 0, '"', 'foo"')
       end
 
-      it { @matcher.parse_block_start('a = "foo"', nil, 0, 0).should be_block_start_like(:double_quote, 4, '"', 'foo"') }
-      it { @matcher.parse_block_start('a = 2', nil, 0, 0).should be_nil }
+      it { expect(@matcher.parse_block_start('a = "foo"', nil, 0, 0)).to be_block_start_like(:double_quote, 4, '"', 'foo"') }
+      it { expect(@matcher.parse_block_start('a = 2', nil, 0, 0)).to be_nil }
 
-      it { @current_block.parse_block_end(' bar"', 0).should be_block_end_like(@current_block, 4, '"', '') }
-      it { @current_block.parse_block_end(' " + bar + "', 0).should be_block_end_like(@current_block, 1, '"', ' + bar + "') }
-      it { @current_block.parse_block_end('\\\\"', 0).should be_block_end_like(@current_block, 2, '"', '') }
-      it { @current_block.parse_block_end('\\" more string"', 0).should be_block_end_like(@current_block, 14, '"', '') }
-      it { @current_block.parse_block_end('a = 2', 0).should be_nil }
-      it { @current_block.parse_block_end('\\"', 0).should be_nil }
-      it { @current_block.parse_block_end('\\\\\\"', 0).should be_nil }
+      it { expect(@current_block.parse_block_end(' bar"', 0)).to be_block_end_like(@current_block, 4, '"', '') }
+      it { expect(@current_block.parse_block_end(' " + bar + "', 0)).to be_block_end_like(@current_block, 1, '"', ' + bar + "') }
+      it { expect(@current_block.parse_block_end('\\\\"', 0)).to be_block_end_like(@current_block, 2, '"', '') }
+      it { expect(@current_block.parse_block_end('\\" more string"', 0)).to be_block_end_like(@current_block, 14, '"', '') }
+      it { expect(@current_block.parse_block_end('a = 2', 0)).to be_nil }
+      it { expect(@current_block.parse_block_end('\\"', 0)).to be_nil }
+      it { expect(@current_block.parse_block_end('\\\\\\"', 0)).to be_nil }
     end
 
     describe 'single_quote' do
@@ -84,12 +84,12 @@ describe 'Ruby' do
         @current_block = RBeautify::BlockStart.new(@matcher, nil, 0, 0, "'", "foo'")
       end
 
-      it { @matcher.should_not be_end_can_also_be_start}
-      it { @matcher.parse_block_start("describe '#foo?' do", nil, 0, 0).should be_block_start_like(:single_quote, 9, "'", "#foo?' do") }
-      it { @matcher.parse_block_start('a = 2', nil, 0, 0).should be_nil }
+      it { expect(@matcher).not_to be_end_can_also_be_start}
+      it { expect(@matcher.parse_block_start("describe '#foo?' do", nil, 0, 0)).to be_block_start_like(:single_quote, 9, "'", "#foo?' do") }
+      it { expect(@matcher.parse_block_start('a = 2', nil, 0, 0)).to be_nil }
 
-      it { @current_block.parse_block_end("#foo?' do", 9).should be_block_end_like(@current_block, 14, "'", ' do')}
-      it { @current_block.parse_block_end('a = 2', 0).should be_nil }
+      it { expect(@current_block.parse_block_end("#foo?' do", 9)).to be_block_end_like(@current_block, 14, "'", ' do')}
+      it { expect(@current_block.parse_block_end('a = 2', 0)).to be_nil }
     end
 
     describe 'continuing_line' do
@@ -98,25 +98,25 @@ describe 'Ruby' do
         @current_block = RBeautify::BlockStart.new(@matcher, nil, 0, 8, ',', '')
       end
 
-      it { @matcher.parse_block_start('foo :bar,', nil, 0, 0).should be_block_start_like(:continuing_line, 8, ',', '') }
-      it { @matcher.parse_block_start('a = 3 &&', nil, 0, 0).should be_block_start_like(:continuing_line, 6, '&&', '') }
-      it { @matcher.parse_block_start('a = 3 ||', nil, 0, 0).should be_block_start_like(:continuing_line, 6, '||', '') }
-      it { @matcher.parse_block_start('a = 3 +', nil, 0, 0).should be_block_start_like(:continuing_line, 6, '+', '') }
-      it { @matcher.parse_block_start('a = 3 -', nil, 0, 0).should be_block_start_like(:continuing_line, 6, '-', '') }
-      it { @matcher.parse_block_start("a \\", nil, 0, 0).should be_block_start_like(:continuing_line, 2, '\\', '') }
-      it { @matcher.parse_block_start('a ?', nil, 0, 0).should be_block_start_like(:continuing_line, 1, ' ?', '')  }
-      it { @matcher.parse_block_start('a ? # some comment', nil, 0, 0).should be_block_start_like(:continuing_line, 1, ' ? # some comment', '') }
-      it { @matcher.parse_block_start('a = 3', nil, 0, 0).should be_nil }
-      it { @matcher.parse_block_start('a = foo.bar?', nil, 0, 0).should be_nil }
-      it { @matcher.parse_block_start('# just a comment', nil, 0, 0).should be_nil }
+      it { expect(@matcher.parse_block_start('foo :bar,', nil, 0, 0)).to be_block_start_like(:continuing_line, 8, ',', '') }
+      it { expect(@matcher.parse_block_start('a = 3 &&', nil, 0, 0)).to be_block_start_like(:continuing_line, 6, '&&', '') }
+      it { expect(@matcher.parse_block_start('a = 3 ||', nil, 0, 0)).to be_block_start_like(:continuing_line, 6, '||', '') }
+      it { expect(@matcher.parse_block_start('a = 3 +', nil, 0, 0)).to be_block_start_like(:continuing_line, 6, '+', '') }
+      it { expect(@matcher.parse_block_start('a = 3 -', nil, 0, 0)).to be_block_start_like(:continuing_line, 6, '-', '') }
+      it { expect(@matcher.parse_block_start("a \\", nil, 0, 0)).to be_block_start_like(:continuing_line, 2, '\\', '') }
+      it { expect(@matcher.parse_block_start('a ?', nil, 0, 0)).to be_block_start_like(:continuing_line, 1, ' ?', '')  }
+      it { expect(@matcher.parse_block_start('a ? # some comment', nil, 0, 0)).to be_block_start_like(:continuing_line, 1, ' ? # some comment', '') }
+      it { expect(@matcher.parse_block_start('a = 3', nil, 0, 0)).to be_nil }
+      it { expect(@matcher.parse_block_start('a = foo.bar?', nil, 0, 0)).to be_nil }
+      it { expect(@matcher.parse_block_start('# just a comment', nil, 0, 0)).to be_nil }
 
-      it { @current_block.parse_block_end('a = 3', 0).should be_block_end_like(@current_block, 0, '', 'a = 3') }
-      it { @current_block.parse_block_end('foo :bar,', 0).should be_nil }
-      it { @current_block.parse_block_end('a = 3 &&', 0).should be_nil }
-      it { @current_block.parse_block_end('a = 3 +', 0).should be_nil }
-      it { @current_block.parse_block_end("a \\", 0).should be_nil }
-      it { @current_block.parse_block_end('# just a comment', 0).should be_nil }
-      it { @current_block.parse_block_end('#', 0).should be_nil }
+      it { expect(@current_block.parse_block_end('a = 3', 0)).to be_block_end_like(@current_block, 0, '', 'a = 3') }
+      it { expect(@current_block.parse_block_end('foo :bar,', 0)).to be_nil }
+      it { expect(@current_block.parse_block_end('a = 3 &&', 0)).to be_nil }
+      it { expect(@current_block.parse_block_end('a = 3 +', 0)).to be_nil }
+      it { expect(@current_block.parse_block_end("a \\", 0)).to be_nil }
+      it { expect(@current_block.parse_block_end('# just a comment', 0)).to be_nil }
+      it { expect(@current_block.parse_block_end('#', 0)).to be_nil }
     end
 
     describe 'round_bracket' do
@@ -125,11 +125,11 @@ describe 'Ruby' do
         @current_block = RBeautify::BlockStart.new(@matcher, nil, 0, 0, '(', '')
       end
 
-      it { @matcher.parse_block_start('a = (foo,', nil, 0, 0).should be_block_start_like(:round_bracket, 4, '(', 'foo,') }
-      it { @matcher.parse_block_start('anything else', nil, 0, 0).should be_nil }
+      it { expect(@matcher.parse_block_start('a = (foo,', nil, 0, 0)).to be_block_start_like(:round_bracket, 4, '(', 'foo,') }
+      it { expect(@matcher.parse_block_start('anything else', nil, 0, 0)).to be_nil }
 
-      it { @current_block.parse_block_end('foo)', 0).should be_block_end_like(@current_block, 3, ')', '') }
-      it { @current_block.parse_block_end('a = 3', 0).should be_nil }
+      it { expect(@current_block.parse_block_end('foo)', 0)).to be_block_end_like(@current_block, 3, ')', '') }
+      it { expect(@current_block.parse_block_end('a = 3', 0)).to be_nil }
     end
 
     describe 'comment' do
@@ -138,12 +138,12 @@ describe 'Ruby' do
         @current_block = RBeautify::BlockStart.new(@matcher, nil, 0, 8, '#', ' comment')
       end
 
-      it { @matcher.parse_block_start('anything # comment', nil, 0, 0).should be_block_start_like(:comment, 8, ' #', ' comment') }
-      it { @matcher.parse_block_start('#', nil, 0, 0).should be_block_start_like(:comment, 0, '#', '') }
-      it { @matcher.parse_block_start('anything else', nil, 0, 0).should be_nil }
+      it { expect(@matcher.parse_block_start('anything # comment', nil, 0, 0)).to be_block_start_like(:comment, 8, ' #', ' comment') }
+      it { expect(@matcher.parse_block_start('#', nil, 0, 0)).to be_block_start_like(:comment, 0, '#', '') }
+      it { expect(@matcher.parse_block_start('anything else', nil, 0, 0)).to be_nil }
 
-      it { @current_block.parse_block_end('anything', 0).should be_block_end_like(@current_block, 8, '', '') }
-      it { @current_block.parse_block_end('', 0).should be_block_end_like(@current_block, 0, '', '') }
+      it { expect(@current_block.parse_block_end('anything', 0)).to be_block_end_like(@current_block, 8, '', '') }
+      it { expect(@current_block.parse_block_end('', 0)).to be_block_end_like(@current_block, 0, '', '') }
     end
 
     describe 'begin' do
@@ -152,13 +152,13 @@ describe 'Ruby' do
         @current_block = RBeautify::BlockStart.new(@matcher, nil, 0, 0, 'begin', '')
       end
 
-      it { @matcher.parse_block_start('begin', nil, 0, 0).should be_block_start_like(:begin, 0, 'begin', '') }
-      it { @matcher.parse_block_start('beginning', nil, 0, 0).should be_nil }
+      it { expect(@matcher.parse_block_start('begin', nil, 0, 0)).to be_block_start_like(:begin, 0, 'begin', '') }
+      it { expect(@matcher.parse_block_start('beginning', nil, 0, 0)).to be_nil }
 
-      it { @current_block.parse_block_end('rescue', 0).should be_block_end_like(@current_block, 0, 'rescue', '') }
-      it { @current_block.parse_block_end('ensure', 0).should be_block_end_like(@current_block, 0, 'ensure', '') }
-      it { @current_block.parse_block_end('else', 0).should be_block_end_like(@current_block, 0, 'else', '') }
-      it { @current_block.parse_block_end('end', 0).should be_block_end_like(@current_block, 0, 'end', '') }
+      it { expect(@current_block.parse_block_end('rescue', 0)).to be_block_end_like(@current_block, 0, 'rescue', '') }
+      it { expect(@current_block.parse_block_end('ensure', 0)).to be_block_end_like(@current_block, 0, 'ensure', '') }
+      it { expect(@current_block.parse_block_end('else', 0)).to be_block_end_like(@current_block, 0, 'else', '') }
+      it { expect(@current_block.parse_block_end('end', 0)).to be_block_end_like(@current_block, 0, 'end', '') }
     end
 
     describe 'regex' do
@@ -167,16 +167,16 @@ describe 'Ruby' do
         @current_block = RBeautify::BlockStart.new(@matcher, nil, 0, 0, '/', 'foo/')
       end
 
-      it { @matcher.parse_block_start('/foo/', nil, 0, 0).should be_block_start_like(:regex, 0, '/', 'foo/') }
-      it { @matcher.parse_block_start(', /foo/', nil, 0, 0).should be_block_start_like(:regex, 0, ', /', 'foo/') }
-      it { @matcher.parse_block_start('foo = /bar/', nil, 0, 0).should be_block_start_like(:regex, 4, '= /', 'bar/') }
-      it { @matcher.parse_block_start('foo =~ /bar/', nil, 0, 0).should be_block_start_like(:regex, 5, '~ /', 'bar/') }
-      it { @matcher.parse_block_start('1/2', nil, 0, 0).should be_nil }
-      it { @matcher.parse_block_start('anything else', nil, 0, 0).should be_nil }
+      it { expect(@matcher.parse_block_start('/foo/', nil, 0, 0)).to be_block_start_like(:regex, 0, '/', 'foo/') }
+      it { expect(@matcher.parse_block_start(', /foo/', nil, 0, 0)).to be_block_start_like(:regex, 0, ', /', 'foo/') }
+      it { expect(@matcher.parse_block_start('foo = /bar/', nil, 0, 0)).to be_block_start_like(:regex, 4, '= /', 'bar/') }
+      it { expect(@matcher.parse_block_start('foo =~ /bar/', nil, 0, 0)).to be_block_start_like(:regex, 5, '~ /', 'bar/') }
+      it { expect(@matcher.parse_block_start('1/2', nil, 0, 0)).to be_nil }
+      it { expect(@matcher.parse_block_start('anything else', nil, 0, 0)).to be_nil }
 
-      it { @current_block.parse_block_end('foo/', 0).should be_block_end_like(@current_block, 3, '/', '') }
-      it { @current_block.parse_block_end('foo/', 0).should be_block_end_like(@current_block, 3, '/', '') }
-      it { @current_block.parse_block_end('', 0).should be_nil }
+      it { expect(@current_block.parse_block_end('foo/', 0)).to be_block_end_like(@current_block, 3, '/', '') }
+      it { expect(@current_block.parse_block_end('foo/', 0)).to be_block_end_like(@current_block, 3, '/', '') }
+      it { expect(@current_block.parse_block_end('', 0)).to be_nil }
 
     end
   end

--- a/spec/rbeautify/line_spec.rb
+++ b/spec/rbeautify/line_spec.rb
@@ -3,69 +3,106 @@ require File.dirname(__FILE__) + '/../spec_helper.rb'
 describe RBeautify::Line do
 
   describe '#format' do
+    let(:config) do
+      {
+        'tab_size' => 2,
+        'translate_tabs_to_spaces' => 'true'
+      }
+    end
 
     before(:each) do
-      @language = mock(RBeautify::Language)
+      @language = double(RBeautify::Language)
     end
 
     it 'should just strip with empty stack' do
-      RBeautify::BlockMatcher.stub!(:parse => nil)
-      RBeautify::Line.new(@language, ' a = 3 ', 0).format.should == "a = 3"
+      expect(RBeautify::BlockMatcher).to receive(:parse).and_return(nil)
+      expect(RBeautify::Line.new(@language, ' a = 3 ', 0, config).format).to eq("a = 3")
     end
 
     it 'should indent with existing indent' do
-      current_block = mock('block_start', :total_indent_size => 2, :format_content? => true, :strict_ancestor_of? => false)
-      RBeautify::BlockStart.stub(:first_common_ancestor => current_block)
-      RBeautify::BlockMatcher.stub!(:parse => current_block)
-      RBeautify::Line.new(@language, ' a = 3 ', 0, current_block).format.should == '  a = 3'
+      current_block = double('block_start',
+        :total_indent_size => 2,
+        :format_content? => true,
+        :strict_ancestor_of? => false
+      )
+      expect(RBeautify::BlockStart).to receive(:first_common_ancestor).at_least(1).and_return(current_block)
+      expect(RBeautify::BlockMatcher).to receive(:parse).and_return(current_block)
+      expect(RBeautify::Line.new(@language, ' a = 3 ', 0, current_block, config).format).to eq('  a = 3')
     end
 
     it 'leave empty lines blank' do
-      current_block = mock('block_start', :format_content? => true)
-      RBeautify::BlockMatcher.stub!(:parse => current_block)
-      RBeautify::Line.new(@language, '    ', 0, current_block).format.should == ''
+      current_block = double('block_start', :format_content? => true)
+      expect(RBeautify::BlockMatcher).to receive(:parse).and_return(current_block)
+      expect(RBeautify::Line.new(@language, '    ', 0, current_block, config).format).to eq('')
     end
 
     it 'should remove indent with match to end of block' do
-      current_block = mock('block_start', :format_content? => true, :indent_end_line? => false)
-      RBeautify::BlockStart.stub(:first_common_ancestor => nil)
-      RBeautify::BlockMatcher.stub!(:parse => nil)
-      RBeautify::Line.new(@language, '  end ', 0, current_block).format.should == 'end'
+      current_block = double('block_start',
+        :format_content? => true,
+        :indent_end_line? => false
+      )
+      expect(RBeautify::BlockStart).to receive(:first_common_ancestor).at_least(1).and_return(nil)
+      expect(RBeautify::BlockMatcher).to receive(:parse).and_return(nil)
+      expect(RBeautify::Line.new(@language, '  end ', 0, current_block, config).format).to eq('end')
     end
 
     it 'should not remove indent with match to end of block if indent_end_line? is true' do
-      current_block = mock('block_start', :total_indent_size => 2, :format_content? => true, :indent_end_line? => true)
-      RBeautify::BlockMatcher.stub!(:parse => nil)
-      RBeautify::Line.new(@language, '  end ', 0, current_block).format.should == '  end'
+      current_block = double('block_start',
+        :total_indent_size => 2,
+        :format_content? => true,
+        :indent_end_line? => true
+      )
+      expect(RBeautify::BlockMatcher).to receive(:parse).and_return(nil)
+      expect(RBeautify::Line.new(@language, '  end ', 0, current_block, config).format).to eq('  end')
     end
 
     it 'should leave indent at old stack level with match of new block' do
-      current_block = mock('current_block_start', :total_indent_size => 2, :format_content? => true)
-      new_block = mock('new_block_start', :format_content? => true, :strict_ancestor_of? => false)
-      RBeautify::BlockStart.stub(:first_common_ancestor => current_block)
-      RBeautify::BlockMatcher.stub!(:parse => new_block)
-      RBeautify::Line.new(@language, 'class Foo', 0, current_block).format.should == '  class Foo'
+      current_block = double('current_block_start',
+        :total_indent_size => 2,
+        :format_content? => true
+      )
+      new_block = double('new_block_start',
+        :format_content? => true,
+        :strict_ancestor_of? => false
+      )
+      expect(RBeautify::BlockStart).to receive(:first_common_ancestor).at_least(1).and_return(current_block)
+      expect(RBeautify::BlockMatcher).to receive(:parse).and_return(new_block)
+      expect(RBeautify::Line.new(@language, 'class Foo', 0, current_block, config).format).to eq('  class Foo')
     end
 
     it 'should remove indent if a block ends and starts' do
-      current_block = mock('current_block_start', :format_content? => true)
-      new_block = mock('new_block_start', :format_content? => true, :strict_ancestor_of? => false)
-      RBeautify::BlockStart.stub(:first_common_ancestor => nil)
-      RBeautify::BlockMatcher.stub!(:parse => new_block)
-      RBeautify::Line.new(@language, '   else   ', 0, current_block).format.should == 'else'
+      current_block = double('current_block_start',
+        :total_indent_size => 0,
+        :format_content? => true
+      )
+      new_block = double('new_block_start',
+        :format_content? => true,
+        :strict_ancestor_of? => false
+      )
+      expect(RBeautify::BlockStart).to receive(:first_common_ancestor).at_least(1).and_return(current_block)
+      expect(RBeautify::BlockMatcher).to receive(:parse).and_return(new_block)
+      expect(RBeautify::Line.new(@language, '   else   ', 0, current_block, config).format).to eq('else')
     end
 
     it 'should not change when format is false' do
-      current_block = mock('block_start', :format_content? => false)
-      RBeautify::BlockMatcher.stub!(:parse => current_block)
-      RBeautify::Line.new(@language, ' some content after program has finished. ', 0, current_block).format.should ==
-        " some content after program has finished. "
+      current_block = double('block_start', :format_content? => false)
+      expect(RBeautify::BlockMatcher).to receive(:parse).and_return(current_block)
+      expect(
+        RBeautify::Line.new(
+          @language,
+          ' some content after program has finished. ', 0,
+          current_block,
+          config
+        ).format
+      ).to eq(" some content after program has finished. ")
     end
 
     it 'should leave indent with match to end of block (but no format)' do
-      current_block = mock('block_start', :format_content? => false)
-      RBeautify::BlockMatcher.stub!(:parse => nil)
-      RBeautify::Line.new(@language, '  "', 0, current_block).format.should == '  "'
+      current_block = double('block_start',
+        :format_content? => false
+      )
+      expect(RBeautify::BlockMatcher).to receive(:parse).and_return(nil)
+      expect(RBeautify::Line.new(@language, '  "', 0, current_block, config).format).to eq('  "')
     end
 
   end


### PR DESCRIPTION
- All specs now pass using RSpec v3.x
- Note: There are still a few deprecation warnings for the custom RBeautifyMatchers code.
