### PR TITLE
Avoid indenting on Rails 4.x validator's 'if:' switch

### DIFF
--- a/lib/rbeautify/block_matcher.rb
+++ b/lib/rbeautify/block_matcher.rb
@@ -77,7 +77,7 @@ module RBeautify
 
     def parse_block_start(string, parent_block, offset, line_number)
       if !string.empty? && (match = starts.match(string))
-        RBeautify::BlockStart.new(self, parent_block, line_number, offset + match.begin(0), match[0], match.post_match)
+        bs = RBeautify::BlockStart.new(self, parent_block, line_number, offset + match.begin(0), match[0], match.post_match)
       end
     end
 

--- a/lib/rbeautify/config/ruby.rb
+++ b/lib/rbeautify/config/ruby.rb
@@ -73,7 +73,7 @@ unless RBeautify::Language.language(:ruby)
                    :nest_except => [:double_quote, :regex, :backtick])
 
   ruby.add_matcher(:if,
-                   /((#{start_statement_boundary}(if|unless))|#{continue_statement_boundary}(then|elsif|else))\b/,
+                   /((#{start_statement_boundary}(if|unless)(?!:))|#{continue_statement_boundary}(then|elsif|else))\b/,
                    /(((^|;|\s)end)|(#{continue_statement_boundary}(then|elsif|else)))\b/,
                    :nest_except => [:case, :double_quote, :regex, :backtick])
 

--- a/spec/rbeautify/config/ruby_spec.rb
+++ b/spec/rbeautify/config/ruby_spec.rb
@@ -39,6 +39,7 @@ describe 'Ruby' do
       it { expect(@matcher.parse_block_start('if foo', nil, 0, 0)).to be_block_start_like(:if, 0, 'if', ' foo') }
       it { expect(@matcher.parse_block_start('then foo = bar', nil, 0, 0)).to be_block_start_like(:if, 0, 'then', ' foo = bar') }
       it { expect(@matcher.parse_block_start('if_foo', nil, 0, 0)).to be_nil }
+      it { expect(@matcher.parse_block_start('if: foo', nil, 0, 0)).to be_nil }
 
       it { expect(@current_block.parse_block_end('end', 0)).to be_block_end_like(@current_block, 0, 'end', '') }
       it { expect(@current_block.parse_block_end('then', 0)).to be_block_end_like(@current_block, 0, 'then', '') }


### PR DESCRIPTION
Uses "negative-lookahead" on `:if` matcher to ensure the found `(if|unless)` is not followed by `:`