### PR TITLE
Support for html.erb tab instead of space indentation and tab_size

### DIFF
--- a/lib/erbbeautify.rb
+++ b/lib/erbbeautify.rb
@@ -1,7 +1,37 @@
 require 'htmlbeautifier'
+module ERBeautify
 
-def beautify(input, output)
-  output.write(HtmlBeautifier.beautify(input))
+  class << self
+    def beautify(input, output, options = {})
+      output.write(HtmlBeautifier.beautify(input, options))
+    end
+
+    def main
+      if(!ARGV[0])
+        STDERR.puts "usage: Ruby filenames or \"-\" for stdin."
+        exit 0
+      else
+        path = ARGV.shift
+        config = generate_config(ARGV)
+        options = Hash.new
+        #https://github.com/threedaymonk/htmlbeautifier/pull/32 waiting on pull request, if is accepted  translate_tabs_to_spaces
+        #will start to work
+        translate_spaces_to_tabs = config['translate_tabs_to_spaces'] == 'False' ? { translate_spaces_to_tabs: true } : Hash.new
+        tab_size = config['tab_size'].to_i != 0 ? { tab_stops: config['tab_size'].to_i } : Hash.new
+        options = options.merge(tab_size).merge(translate_spaces_to_tabs)
+        beautify $stdin.read.force_encoding('utf-8'), $stdout, options
+      end
+    end
+
+    def generate_config args
+      args.each_slice(2).with_object({}) do |parameter, result|
+        result[parameter.first.gsub('--','').gsub('-','_')] = parameter.last
+      end
+    end
+  end
 end
 
-beautify $stdin.read.force_encoding('utf-8'), $stdout
+# if launched as a standalone program, not loaded as a module
+if __FILE__ == $0
+  ERBeautify.main
+end


### PR DESCRIPTION
Hi, i wasn't sure to open this pull request, but i add a little support for tab_size and translate_tabs_to_spaces on html.erb files, the problem is that i also add a little of code on HtmlBeautifier, i gonna also upload a pull request in there, if they accepted i will let you know, by the way, removing this 
```ruby
translate_spaces_to_tabs = config['translate_tabs_to_spaces'] == 'False' ? { translate_spaces_to_tabs: true } : Hash.new
```
would still use the tab_size option whitout the pull request on HtmlBeautifier, it would need to change the next line to avoid the merge with translate_spaces_to_tabs  variable and clean it a little, also i change the readme for my github, i'll let you know if i got any news