### PR TITLE
Changes need it to match htmlbeautifier translate_tabs_to_spaces=false

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,14 @@ By default, Sublime does not translate tabs to spaces. If you wish to use tabs y
 "translate_tabs_to_spaces": true
 ```
 
+Or if you wish to force the use of tabs use:
+
+```
+"translate_tabs_to_spaces": false
+```
+
+If translate_tabs_to_spaces is set to *false* tab_size will not be used.
+
 ### Tab size
 
 Sublime's default `tab_size` is set to 4. Override this setting to change the number of spaces to use when using spaces instead of tabs.

--- a/lib/erbbeautify.rb
+++ b/lib/erbbeautify.rb
@@ -14,10 +14,8 @@ module ERBeautify
         path = ARGV.shift
         config = generate_config(ARGV)
         options = Hash.new
-        #https://github.com/threedaymonk/htmlbeautifier/pull/32 waiting on pull request, if is accepted  translate_tabs_to_spaces
-        #will start to work
-        translate_spaces_to_tabs = config['translate_tabs_to_spaces'] == 'False' ? { translate_spaces_to_tabs: true } : Hash.new
-        tab_size = config['tab_size'].to_i != 0 ? { tab_stops: config['tab_size'].to_i } : Hash.new
+        translate_spaces_to_tabs = config['translate_tabs_to_spaces'] == 'False' ? { indent: "\t" } : Hash.new
+        tab_size = (config['tab_size'].to_i != 0 and config['translate_tabs_to_spaces'] != 'False') ? { tab_stops: config['tab_size'].to_i } : Hash.new
         options = options.merge(tab_size).merge(translate_spaces_to_tabs)
         beautify $stdin.read.force_encoding('utf-8'), $stdout, options
       end


### PR DESCRIPTION
Hi, some time ago i submit a change to be able to convert spaces to tabs, today htmlbeautifier "accept" the pull request, actually with his own implementation, so with this changes it would work as well, the changes are at the master branch, don't know when this will become a full release to just update it with bundle, but you can pull the gem from the master branch to test it, please check the spelling on the readme modifications, regards!