### PR TITLE
Add support for keep blank lines in htmlbeautifier gem

### DIFF
--- a/beautify_ruby.py
+++ b/beautify_ruby.py
@@ -11,11 +11,14 @@ class BeautifyRubyOnSave(sublime_plugin.EventListener):
 class BeautifyRubyCommand(sublime_plugin.TextCommand):
   def run(self, edit, error=True, save=True):
     self.load_settings()
-    self.view.settings().set('translate_tabs_to_spaces', self.settings.get('translate_tabs_to_spaces'))
-    self.view.settings().set('tab_size', self.settings.get('tab_size'))
+
+    for s in ['translate_tabs_to_spaces', 'tab_size', 'keep_blank_lines']:
+      self.view.settings().set(s, self.settings.get(s))
+
     self.filename = self.view.file_name()
     self.fname = os.path.basename(self.filename)
     self.erb = self.is_erb_file()
+
     try:
       if self.erb or self.is_ruby_file():
         self.beautify_buffer(edit)
@@ -75,12 +78,13 @@ class BeautifyRubyCommand(sublime_plugin.TextCommand):
 
   def config_params(self):
     def create_parameter(name):
-      return ['--'+name.replace('_','-'), str(self.view.settings().get(name)) ]
+      return ['--'+name.replace('_','-'), str(self.view.settings().get(name))]
 
     result = []
-    targets = ["tab_size","translate_tabs_to_spaces",'default_line_ending']
+    targets = ["tab_size","translate_tabs_to_spaces",'default_line_ending','keep_blank_lines']
     for target in targets:
       result += create_parameter(target)
+
     return result
 
   def load_settings(self):

--- a/lib/erbbeautify.rb
+++ b/lib/erbbeautify.rb
@@ -14,9 +14,19 @@ module ERBeautify
         path = ARGV.shift
         config = generate_config(ARGV)
         options = Hash.new
-        translate_spaces_to_tabs = config['translate_tabs_to_spaces'] == 'False' ? { indent: "\t" } : Hash.new
-        tab_size = (config['tab_size'].to_i != 0 and config['translate_tabs_to_spaces'] != 'False') ? { tab_stops: config['tab_size'].to_i } : Hash.new
-        options = options.merge(tab_size).merge(translate_spaces_to_tabs)
+
+        if config['translate_tabs_to_spaces'] == 'False'
+          options[:indent] = '\t'
+        end
+
+        if config['tab_size'].to_i != 0 and config['translate_tabs_to_spaces'] != 'False'
+          options[:tab_stops] = config['tab_size'].to_i
+        end
+
+        if config['keep_blank_lines'].to_i > 0
+          options[:keep_blank_lines] = config['keep_blank_lines'].to_i
+        end
+
         beautify $stdin.read.force_encoding('utf-8'), $stdout, options
       end
     end


### PR DESCRIPTION
I wasn't enjoying the way beautifier was removing all of my carefully placed blank lines in my erb files. I then found that the html beautify gem already supports keeping these in place:

[original implementation](https://github.com/threedaymonk/htmlbeautifier/commit/44c0fc3059e6da2fd69a880057c2aa6a63aed44b)
[name change](https://github.com/threedaymonk/htmlbeautifier/commit/5c78b885b45a4fc8091df4dbfb4ca360c37157cd)

This plugin just needed to be updated to pass through the parameter that controlled that.