### PR TITLE
Support for Windows Subsystem for Linux WSL

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,12 @@ If you use project-specific rubies and gem sets managed with `rvm`, then simply 
 
 and then the `htmlbeautifier` gem is found even if it is only installed for this project.
 
+If you are using ruby on the Windows Subsystem for Linux, use:
+
+```
+  "ruby": "wsl ruby"
+```
+
 ### Tabs or Spaces
 
 By default, Sublime does not translate tabs to spaces. If you wish to use tabs you will not need to change your settings. If you wish to use spaces, add the following setting.

--- a/beautify_ruby.py
+++ b/beautify_ruby.py
@@ -60,6 +60,10 @@ class BeautifyRubyCommand(sublime_plugin.TextCommand):
 
     args = ["'" + str(path) + "'"] + self.config_params()
 
+    # Use translated path when wsl ruby
+    if self.settings.get('ruby') == 'wsl ruby':
+      ruby_script = subprocess.check_output("wsl wslpath '" + ruby_script + "'", shell=True).decode("utf-8").rstrip()
+
     return ruby_interpreter + " '" + ruby_script + "' " + ' '.join(args)
 
   def finalize_output(self, text):


### PR DESCRIPTION
I had this hard coded locally for a while now, but didn't create a pull request because there wasn't a nice way to do it before, this days windows added a command for translate windows paths to linux paths called wslpath, with that now it would be able to translate paths on demand, with one extra call to the system, it would also keep all the existing behavior, but before sending the call, to the ruby inside the linux subsystem, it would translate the path to the linux format when the ruby option is set to `"ruby": "wsl ruby"`.
There are lots of ways to achieve this, but this seems to be the cleanest.